### PR TITLE
Handle HEAD Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Build and run it in a modern Docker as follows:
 
 This service is running on http://version99.grons.nl. However, I encourage you to run this service yourself as bandwidth to my machine is limited.
 
-Often you only need this sevice for just 1 package. In that case you can also download the jar and pom for that package and upload it to your local repository (that is, if you have one).
+Often you only need this service for just 1 package. In that case you can also download the jar and pom for that package and upload it to your local repository (that is, if you have one).
 
 ## Update April 2019
 

--- a/src/helper.go
+++ b/src/helper.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"regexp"
+	"strings"
 )
 
 // --------------------------------------------------------------------
@@ -34,7 +35,7 @@ func matchMavenURI(uri string) *maven {
 		return nil
 	}
 
-	return &maven{GroupId: m[1], ArtifactId: m[2], Name: m[3], Ext: m[4], Digest: m[6], InfoURL: INFO_URL}
+	return &maven{GroupId: strings.ReplaceAll(m[1], "/", "."), ArtifactId: m[2], Name: m[3], Ext: m[4], Digest: m[6], InfoURL: INFO_URL}
 }
 
 // --------------------------------------------------------------------

--- a/src/http.go
+++ b/src/http.go
@@ -99,8 +99,15 @@ var (
 // --------------------------------------------------------------------
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "GET" {
-		sendStatus(http.StatusBadRequest, w, r)
+
+	if r.Method != "GET" && r.Method != "HEAD" {
+		sendStatus(http.StatusMethodNotAllowed, w, r)
+		return
+	}
+
+	// Handle HEAD request
+	if r.Method == "HEAD" {
+		sendStatus(http.StatusOK, w, r)
 		return
 	}
 
@@ -150,4 +157,3 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 	sendNotFound(w, r)
 }
-

--- a/src/http.go
+++ b/src/http.go
@@ -41,7 +41,7 @@ img { width:1em; height:1em; position:relative; top:2px; }
 <h1><img src="/favicon.png"> Version 99 Does Not Exist</h1>
 <p>Please see <a href="http://day-to-day-stuff.blogspot.com/2007/10/announcement-version-99-does-not-exist.html">my blog</a> to read why I created Version 99 Does Not Exist and its predecessor no-commons-logging.</p>
 <p>Version 99 Does Not Exist emulates a Maven 2 repository and serves empty jars for any valid package that has version number <i>99.0-does-not-exist</i>. It also generates poms, <span style="text-decoration: line-through">metadata files</span> (removed since 2.0) and of course the appropriate hashes.</p>
-<p>For example the following links will give an <a href="http://version99.grons.nl/mvn2/commons-logging/commons-logging/99.0-does-not-exist/commons-logging-99.0-does-not-exist.jar">empty jar</a>, its <a href="http://version99.grons.nl/mvn2/commons-logging/commons-logging/99.0-does-not-exist/commons-logging-99.0-does-not-exist.pom">pom</a> and the <a href="http://version99.grons.nl/mvn2/commons-logging/commons-logging/maven-metadata.xml"><span style="text-decoration: line-through">maven metadata</span></a> for commons-logging.</p>
+<p>For example the following links will give an <a href="/mvn2/commons-logging/commons-logging/99.0-does-not-exist/commons-logging-99.0-does-not-exist.jar">empty jar</a>, its <a href="/mvn2/commons-logging/commons-logging/99.0-does-not-exist/commons-logging-99.0-does-not-exist.pom">pom</a> and the <a href="/mvn2/commons-logging/commons-logging/maven-metadata.xml"><span style="text-decoration: line-through">maven metadata</span></a> for commons-logging.</p>
 <p><a href="https://github.com/erikvanoosten/version99">Vesion 99 Does Not Exist source code on GitHub.</a></p>
 </body>
 </html>`


### PR DESCRIPTION
Maven Version 3.8.1 may now send HEAD requests before fetching artifacts.

It should also be noted that there's a requirement for https for repositories that are not running on localhost.